### PR TITLE
SystemPreferences: activate video mode via Apply

### DIFF
--- a/Modules/Video/WaylandBackend.cpp
+++ b/Modules/Video/WaylandBackend.cpp
@@ -1,0 +1,30 @@
+// WaylandBackend.cpp (debug stub)
+#include "DisplayBackend.hpp"
+#include <cstdio>
+#include <memory>
+
+class WaylandBackend : public DisplayBackend {
+public:
+  WaylandBackend() { std::fprintf(stderr, "[WaylandBackend] init\n"); }
+  ~WaylandBackend() override { std::fprintf(stderr, "[WaylandBackend] destroy\n"); }
+
+  std::vector<OutputInfo> listOutputs() override {
+    std::fprintf(stderr, "[WaylandBackend] listOutputs\n");
+    return {};
+  }
+
+  bool setMode(const std::string& outputName, const std::string& modeId) override {
+    std::fprintf(stderr, "[WaylandBackend] setMode %s -> %s\n", outputName.c_str(), modeId.c_str());
+    return false;
+  }
+
+  bool revert(const std::string& outputName) override {
+    std::fprintf(stderr, "[WaylandBackend] revert %s\n", outputName.c_str());
+    return false;
+  }
+};
+
+std::unique_ptr<DisplayBackend> MakeWaylandBackend() {
+  std::fprintf(stderr, "[Factory] MakeWaylandBackend\n");
+  return std::unique_ptr<DisplayBackend>(new WaylandBackend());
+}

--- a/Modules/Video/X11Backend.cpp
+++ b/Modules/Video/X11Backend.cpp
@@ -7,6 +7,7 @@ extern "C" {
 #include <unordered_map>
 #include <memory>
 #include <sstream>
+#include <cstdio>
 
 class X11Backend : public DisplayBackend {
   Display* dpy_{nullptr};
@@ -16,12 +17,17 @@ class X11Backend : public DisplayBackend {
   std::unordered_map<std::string, Orig> originals_;
 public:
   X11Backend() {
+    std::fprintf(stderr, "[X11Backend] init\n");
     dpy_ = XOpenDisplay(nullptr);
     if (dpy_) { screen_ = DefaultScreen(dpy_); root_ = RootWindow(dpy_, screen_); }
   }
-  ~X11Backend() override { if (dpy_) XCloseDisplay(dpy_); }
+  ~X11Backend() override {
+    std::fprintf(stderr, "[X11Backend] destroy\n");
+    if (dpy_) XCloseDisplay(dpy_);
+  }
 
   std::vector<OutputInfo> listOutputs() override {
+    std::fprintf(stderr, "[X11Backend] listOutputs\n");
     std::vector<OutputInfo> out;
     if (!dpy_) return out;
     XRRScreenResources* res = XRRGetScreenResourcesCurrent(dpy_, root_);
@@ -61,6 +67,7 @@ public:
   }
 
   bool setMode(const std::string& name, const std::string& modeId) override {
+    std::fprintf(stderr, "[X11Backend] setMode %s -> %s\n", name.c_str(), modeId.c_str());
     if (!dpy_) return false;
     XRRScreenResources* res = XRRGetScreenResourcesCurrent(dpy_, root_);
     if (!res) return false;
@@ -90,6 +97,7 @@ public:
   }
 
   bool revert(const std::string& name) override {
+    std::fprintf(stderr, "[X11Backend] revert %s\n", name.c_str());
     if (!dpy_) return false;
     auto it = originals_.find(name);
     if (it == originals_.end()) return false;
@@ -105,5 +113,6 @@ public:
 
 // factory
 std::unique_ptr<DisplayBackend> MakeX11Backend() {
+  std::fprintf(stderr, "[Factory] MakeX11Backend\n");
   return std::unique_ptr<DisplayBackend>(new X11Backend());
 }


### PR DESCRIPTION
## Summary
- make Apply button commit the selected video mode
- avoid switching modes immediately on selection
- add debug logging in VideoModule and display backends

## Testing
- `make` *(fails: GNUmakefile:36: You need to run the GNUstep configuration script before compiling!)*


------
https://chatgpt.com/codex/tasks/task_e_68b6b78b72e483308b5e87a8c4d1f987