### PR TITLE
Add NSToolbar for Show All controls

### DIFF
--- a/SystemPreferences/SystemPreferences.h
+++ b/SystemPreferences/SystemPreferences.h
@@ -30,6 +30,7 @@
 @class NSWindow;
 @class NSBox;
 @class SPIconsView;
+@class NSToolbarItem;
 
 @interface SystemPreferences : NSObject
 {
@@ -38,6 +39,7 @@
   IBOutlet NSWindow *win;
   IBOutlet NSBox *controlsBox;
   IBOutlet id showAllButt;
+  NSToolbarItem *showAllItem;
   IBOutlet NSBox *prefsBox;
   
   NSMutableArray *panes;


### PR DESCRIPTION
## Summary
- Add NSToolbar to main SystemPreferences window
- Move existing Show All button into toolbar and manage its state
- Provide toolbar delegate methods for Show All item

## Testing
- `make` *(fails: You need to run the GNUstep configuration script before compiling)*

------
https://chatgpt.com/codex/tasks/task_e_68c07472064c8330b50558abec0b4728